### PR TITLE
verify_challenge: req_type is bytes()

### DIFF
--- a/pwdsphinx/oracle.py
+++ b/pwdsphinx/oracle.py
@@ -486,7 +486,7 @@ def verify_challenge(conn):
 
   # read request
   req_type = conn.read(1)
-  if req_type == READ:
+  if req_type[0] == READ:
     payload = conn.read(32)
     if len(payload)!=32: fail(conn)
   else:


### PR DESCRIPTION
while `READ` is an `int`, comparing them will always fail