### PR TITLE
fix docu

### DIFF
--- a/GettingStarted.md
+++ b/GettingStarted.md
@@ -24,11 +24,11 @@ But before skipping you might also want to install these optional dependencies:
 ```
 
 If you are not on debian derivates, you need to build two dependencies
-manually. Let's start with libsphinx:
+manually. Let's start with liboprf:
 
 ```
-% git clone https://github.com/stef/libsphinx
-% cd libsphinx/src
+% git clone https://github.com/stef/liboprf
+% cd liboprf/src
 % sudo apt install install python3 libsodium libsodium-dev
 % sudo PREFIX=/usr make install
 ```

--- a/sphinx.cfg_sample
+++ b/sphinx.cfg_sample
@@ -45,7 +45,7 @@
 # existing passwords.
 [servers.first]
 # the ip address of the server
-address="127.0.0.1"
+host="127.0.0.1"
 # the port where the server is running, 443 is nice to punch through firewalls.
 port=443
 # the long term signature key of the server.
@@ -56,12 +56,12 @@ ltsigkey="32byteBase64EncodedValue=="
 # in case you want to use a threshold version of SPHINX you need at least 3
 # servers (and the threshold is then 2)
 #[servers.2nd]
-#address="127.0.0.1"
+#host="127.0.0.1"
 #port=2355
 #ltsigkey="2nd.pub"
 #
 #[servers.3rd]
-#address="127.0.0.1"
+#host="127.0.0.1"
 #port=5523
 #ltsigkey="3rd.pub"
 

--- a/whitepaper.org
+++ b/whitepaper.org
@@ -83,7 +83,7 @@ Let's recap how the SPHINX query works:
 
 #+BEGIN_SRC
  r = random(32)
- alpha = (r*hash(pwd))
+ alpha = (r * hash(pwd))
 #+END_SRC
 
 The * operation denotes scalar multiplication over an elliptic curve
@@ -95,7 +95,7 @@ hash-to-curve operation.
 the blinded hash of the users password:
 
 #+BEGIN_SRC
- beta = seed*alfa
+ beta = seed * alpha
 #+END_SRC
 
 The server returns the calculated beta value to the client.
@@ -109,7 +109,7 @@ and hashes it again with the master password, which results in
 the rwd:
 
 #+BEGIN_SRC
- rwd = hash(pwd,pwd_k)
+ rwd = hash(pwd, pwd_k)
 #+END_SRC
 
 So far this is regular a regular generic OPRF, as specified by RFC9497 and
@@ -530,7 +530,7 @@ pubkey is generated as such:
 #+BEGIN_SRC
   key0 = blake2b("sphinx signing key", masterkey)
   seed = blake2b(key0, id)
-  pk, sk = e25519_keypair(seed)
+  pk, sk = ed25519_keypair(seed)
 #+END_SRC
 
 The parameter id used to calculate key1 is the record id, we use this
@@ -558,7 +558,7 @@ added to the key:
   key0 = blake2b("sphinx signing key", masterkey)
   key1 = blake2b(key0, id)
   seed = blake2b(key1, rwd)
-  pk, sk = e25519_keypair(seed)
+  pk, sk = ed25519_keypair(seed)
 #+END_SRC
 
 The rwd is the raw output of the SPHINX protocol, and by mixing it


### PR DESCRIPTION
Hi,

I have installed the Version 2.0.3.

Here are a few improvements in your docu. Perhaps you want to use them.

If I use 

```
[servers.first]
 # the ip address of the server
address="127.0.0.1"
```

 instead of 

```
[servers.first]
 # the ip address of the server
host="127.0.0.1"
```

 I get the following error message:

```
Traceback (most recent call last):
  File "/home/vagrant/venv/bin/sphinx", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/vagrant/venv/lib/python3.12/site-packages/pwdsphinx/sphinx.py", line 1094, in main
    m = Multiplexer(servers)
        ^^^^^^^^^^^^^^^^^^^^
  File "/home/vagrant/venv/lib/python3.12/site-packages/pwdsphinx/sphinx.py", line 40, in __init__
    ,(p['host'],p['port'])
      ~^^^^^^^^
KeyError: 'host'
```