### PR TITLE
rename functions

### DIFF
--- a/pwdsphinx/oracle.py
+++ b/pwdsphinx/oracle.py
@@ -740,7 +740,7 @@ def ratelimit(conn):
    elif op == CHALLENGE_VERIFY:
      verify_challenge(conn)
 
-def main(debug=False):
+def start_server(debug=False):
     if debug == True:
         import ctypes
         libc = ctypes.cdll.LoadLibrary('libc.so.6')
@@ -824,7 +824,7 @@ def missing_file(path):
     print(f"Aborting.")
     exit(1)
 
-def parse_params():
+def main():
   if not is_readable(ssl_key):
     missing_file(ssl_key)
   if not is_readable(ssl_cert):
@@ -841,7 +841,7 @@ def parse_params():
   if 'debug' in sys.argv:
     debug = True
   if not 'init' in sys.argv:
-    main(debug)
+    start_server(debug)
   else:
     # init
     pk, sk = pysodium.crypto_sign_keypair()
@@ -859,4 +859,4 @@ def parse_params():
     print(f"{binascii.b2a_base64(pk).strip().decode('utf8')}")
 
 if __name__ == '__main__':
-  parse_params()
+  main()

--- a/pwdsphinx/oracle.py
+++ b/pwdsphinx/oracle.py
@@ -740,7 +740,7 @@ def ratelimit(conn):
    elif op == CHALLENGE_VERIFY:
      verify_challenge(conn)
 
-def start_server(debug=False):
+def main(debug=False):
     if debug == True:
         import ctypes
         libc = ctypes.cdll.LoadLibrary('libc.so.6')
@@ -824,7 +824,7 @@ def missing_file(path):
     print(f"Aborting.")
     exit(1)
 
-def main():
+def parse_params():
   if not is_readable(ssl_key):
     missing_file(ssl_key)
   if not is_readable(ssl_cert):
@@ -841,7 +841,7 @@ def main():
   if 'debug' in sys.argv:
     debug = True
   if not 'init' in sys.argv:
-    start_server(debug)
+    main(debug)
   else:
     # init
     pk, sk = pysodium.crypto_sign_keypair()
@@ -859,4 +859,4 @@ def main():
     print(f"{binascii.b2a_base64(pk).strip().decode('utf8')}")
 
 if __name__ == '__main__':
-  main()
+  parse_params()

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(name = 'pwdsphinx',
                    ],
        entry_points = {
            'console_scripts': [
-               'oracle = pwdsphinx.oracle:main',
+               'oracle = pwdsphinx.oracle:parse_params',
                'sphinx = pwdsphinx.sphinx:main',
                'websphinx = pwdsphinx.websphinx:main',
                'bin2pass = pwdsphinx.bin2pass:main',


### PR DESCRIPTION
Hi,

if you call `oracle init`, for example, the function `def parse_params()` is not called. This means that no `ltsigkey` pair is generated. I have therefore renamed the functions so that a `ltsigkey` pair is also generated when `oracle init` is called.

The name `start_server` is just a suggestion.