### PR TITLE
remove default ALPN value from sphinx.py

### DIFF
--- a/pwdsphinx/sphinx.py
+++ b/pwdsphinx/sphinx.py
@@ -530,7 +530,7 @@ def init():
   init_browser_ext()
   create_masterkey()
   # create health check record
-  m = Multiplexer(servers, ['sphinx/1'])
+  m = Multiplexer(servers)
   m.connect()
   create(m, b"all ok?", "healthcheck", "sphinx servers", target="everything works fine")
   return 0


### PR DESCRIPTION
e0d70c3 removed the monkey-patched constructor, however, this call site remained with the additional parameter, which was not expected by pyoprf, resulting in a crash for all `sphinx` command invocations